### PR TITLE
Fix ios cold deeplink issue

### DIFF
--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -38,7 +38,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin, UNUserNotific
         if let userInfo = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any] {
             pendingNotificationTap = userInfo
         }
-        return false
+        return true
     }
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter,


### PR DESCRIPTION
* The return value of `application:didFinishLaunchingWithOptions:` tells iOS whether the app could handle the resource it was launched with — specifically an URL or an NSUserActivity (web link). 
* When the app is cold-launched by tapping a web link, iOS checks this return value. If it's NO/false, iOS treats the launch as "the app declined to handle it" and skip delivering the continuation to `application:continueUserActivity:`, so your web link silently fails on a cold start (but works when the app is already running/warm).